### PR TITLE
Add support for generating Rust enums from Move enums

### DIFF
--- a/move-binding-derive/tests/test.rs
+++ b/move-binding-derive/tests/test.rs
@@ -23,6 +23,8 @@ move_contract! {alias = "deepbook", package = "@deepbook/core", deps = [crate::s
 
 //move_contract! {alias = "mvr_metadata_testnet", package = "@mvr/metadata", network = "testnet", deps = [crate::sui]}
 
+move_contract! {alias = "commander", package = "0xdc931e30acc15dbc7fcbd39cd385a03894a7236761490ff4d5b9dbf51af3ce26", network="testnet", deps = [crate::sui, crate::sui_system]}
+
 #[tokio::test]
 pub async fn test_deserialize_object() {
     let client = Client::new("https://sui-mainnet.mystenlabs.com/graphql").unwrap();
@@ -82,4 +84,61 @@ pub async fn test_function_call() {
     let result = client.dry_run_tx(&tx, None).await.unwrap();
 
     println!("{:?}", result);
+}
+
+#[tokio::test]
+async fn test_deserialize_enum() {
+    use commander::history;
+
+    // Struct Variant
+    let attack = history::Record::Attack {
+        origin: vec![1, 1],
+        target: vec![2, 7],
+    };
+    let bytes = bcs::to_bytes(&attack).unwrap();
+    let deserialized: history::Record = bcs::from_bytes(&bytes).unwrap();
+    println!("Deserialized: {:?}", deserialized);
+
+    // Tuple variant
+    let reload = history::Record::Reload(vec![4, 7, 8, 22]);
+    let bytes = bcs::to_bytes(&reload).unwrap();
+    let deserialized: history::Record = bcs::from_bytes(&bytes).unwrap();
+    println!("Deserialized: {:?}", deserialized);
+
+    // Unit variant
+    let miss = history::Record::Miss;
+    let bytes = bcs::to_bytes(&miss).unwrap();
+    let deserialized: history::Record = bcs::from_bytes(&bytes).unwrap();
+    println!("Deserialized: {:?}", deserialized);
+
+    // let client = Client::new("https://sui-testnet.mystenlabs.com/graphql").unwrap();
+
+    // let owner = Address::from_str("0x0").unwrap();
+    // let gas =
+    //     ObjectId::from_str("0x036c1be41526a4d38c3e128abfc6f5f46786aa66216a1aff82e05687a0a4d059")
+    //         .unwrap();
+    // let gas = client.object(gas.into(), None).await.unwrap().unwrap();
+
+    // let mut builder = TransactionBuilder::new();
+    // builder.set_sender(owner);
+    // builder.add_gas_objects(vec![Input::owned(
+    //     gas.object_id(),
+    //     gas.version(),
+    //     gas.digest(),
+    // )]);
+    // builder.set_gas_budget(10000000);
+    // builder.set_gas_price(1000);
+
+    // let mut new_history = history::empty(&mut builder);
+    // let attack = history::new_attack(&mut builder, vec![3, 4].into(), vec![1, 5].into());
+
+    // history::add(&mut builder, new_history.borrow_mut(), attack);
+
+    // let dodged = history::new_dodged(&mut builder);
+    // history::add(&mut builder, new_history.borrow_mut(), dodged);
+
+    // let tx = builder.finish().unwrap();
+    // let result = client.dry_run_tx(&tx, None).await.unwrap();
+
+    // println!("Result: {:?}", result);
 }

--- a/move-binding-derive/tests/test.rs
+++ b/move-binding-derive/tests/test.rs
@@ -110,35 +110,4 @@ async fn test_deserialize_enum() {
     let bytes = bcs::to_bytes(&miss).unwrap();
     let deserialized: history::Record = bcs::from_bytes(&bytes).unwrap();
     println!("Deserialized: {:?}", deserialized);
-
-    // let client = Client::new("https://sui-testnet.mystenlabs.com/graphql").unwrap();
-
-    // let owner = Address::from_str("0x0").unwrap();
-    // let gas =
-    //     ObjectId::from_str("0x036c1be41526a4d38c3e128abfc6f5f46786aa66216a1aff82e05687a0a4d059")
-    //         .unwrap();
-    // let gas = client.object(gas.into(), None).await.unwrap().unwrap();
-
-    // let mut builder = TransactionBuilder::new();
-    // builder.set_sender(owner);
-    // builder.add_gas_objects(vec![Input::owned(
-    //     gas.object_id(),
-    //     gas.version(),
-    //     gas.digest(),
-    // )]);
-    // builder.set_gas_budget(10000000);
-    // builder.set_gas_price(1000);
-
-    // let mut new_history = history::empty(&mut builder);
-    // let attack = history::new_attack(&mut builder, vec![3, 4].into(), vec![1, 5].into());
-
-    // history::add(&mut builder, new_history.borrow_mut(), attack);
-
-    // let dodged = history::new_dodged(&mut builder);
-    // history::add(&mut builder, new_history.borrow_mut(), dodged);
-
-    // let tx = builder.finish().unwrap();
-    // let result = client.dry_run_tx(&tx, None).await.unwrap();
-
-    // println!("Result: {:?}", result);
 }


### PR DESCRIPTION
## Description

This PR addresses a problem in the `move-binding-derive` crate where enum types were not generated, causing errors like "cannot find type in module" when interacting with contracts (e.g., [0xdc931e30acc15dbc7fcbd39cd385a03894a7236761490ff4d5b9dbf51af3ce26](https://github.com/sui-potatoes/app/blob/5d76b9ffe0946b9220d94803262df507c710f42a/packages/commander-v2/sources/map/history.move)). The absence of enum type generation in the binding code was the root cause. This PR introduces support for generating Rust enums from Move enums, aligning with the existing struct generation logic.

## Changes

-   Added logic to detect and generate Rust enums from Move enum definitions.
-   Implemented support for enum variants, including unit variants, tuple variants, and struct variants.
-   Ensured generated enums include required derives (`serde::Deserialize`, `serde::Serialize`, `Debug`, `MoveStruct`) and type origin metadata.

## Impact

-   **Fixes the Problem**: Generated enums are now included in the binding, resolving "type not found" errors for contracts.
-   **Workspace Usage**: Enums can be used directly within the workspace for local contract interactions.
-   **Known Limitation**: As noted in [Sui Limitation #19269](https://github.com/MystenLabs/sui/issues/19269), generated enums cannot be passed as arguments to contract function calls due to a limitation in the Sui framework, which is not addressed in this PR.

## Testing

-   Verified that bindings compile without errors for contracts with enum types.
-   Confirmed that generated enums are usable in the workspace.
-   Acknowledged the argument-passing limitation, consistent with the referenced Sui limitation.

Please review the changes and let me know if further clarifications or tests are needed!
